### PR TITLE
fix: parseStringAsArray, error when undefined techs

### DIFF
--- a/backend/src/utils/parseStringAsArray.js
+++ b/backend/src/utils/parseStringAsArray.js
@@ -1,3 +1,7 @@
 module.exports = function parseStringAsArray(arrayAsString) {
+  if (!arrayAsString) {
+    return [];
+  }
+
   return arrayAsString.split(',').map(tech => tech.trim());
 }


### PR DESCRIPTION
Correção para o erro que irá ocorrer o parâmetro **techs** não seja passado na requisição. 

Da forma como foi tratado o erro, a função irá sempre retornar um array, no caso de não ser passado o atributo **techs** na requisição, a função não mais dará um erro, e sim retornará um array vazio.

Fixes #3